### PR TITLE
MONIT-10728 Remove event counters from lambda wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,8 @@ The Lambda wrapper sends the following standard lambda metrics to wavefront:
 | Metric Name                       |  Type              | Description                                                             |
 | ----------------------------------|:------------------:| ----------------------------------------------------------------------- |
 | aws.lambda.wf.invocations.count   | Delta Counter      | Count of number of lambda function invocations aggregated at the server.|
-| aws.lambda.wf.invocation_event.count   |  Counter      | Count of number of lambda function invocations.|
 | aws.lambda.wf.errors.count        | Delta Counter      | Count of number of errors aggregated at the server.                     |
-| aws.lambda.wf.error_event.count        |  Counter      | Count of number of errors.                     |
 | aws.lambda.wf.coldstarts.count    | Delta Counter      | Count of number of cold starts aggregated at the server.                |
-| aws.lambda.wf.coldstart_event.count| Counter           | Count of number of cold starts.                                         |
 | aws.lambda.wf.duration.value      | Gauge              | Execution time of the Lambda handler function in milliseconds.          |
 
 The Lambda wrapper adds the following point tags to all metrics sent to wavefront:

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@
 from setuptools import setup, find_packages  # noqa: H301
 
 NAME = "wavefront_lambda"
-VERSION = "0.9.3"
+VERSION = "0.9.4"
 # To install the library, run the following
 #
 # python setup.py install

--- a/wavefront_lambda/__init__.py
+++ b/wavefront_lambda/__init__.py
@@ -21,26 +21,20 @@ def wrapper(func):
     """
     def call_lambda_with_standard_metrics(wf_reporter, *args, **kwargs):
         METRIC_PREFIX = "aws.lambda.wf."
-        METRIC_EVENT_SUFFIX = "_event"
         # Register cold start counter
         aws_cold_starts_counter = delta.delta_counter(reg, METRIC_PREFIX + "coldstarts")
-        aws_cold_start_event_counter = reg.counter(METRIC_PREFIX + "coldstart" + METRIC_EVENT_SUFFIX)
         global is_cold_start
         if is_cold_start:
             # Set cold start counter.
             aws_cold_starts_counter.inc()
-            aws_cold_start_event_counter.inc()
             is_cold_start = False
         # Set invocations counter
         aws_lambda_invocations_counter = delta.delta_counter(reg, METRIC_PREFIX + "invocations")
         aws_lambda_invocations_counter.inc()
-        aws_lambda_invocation_event_counter = reg.counter(METRIC_PREFIX + "invocation" + METRIC_EVENT_SUFFIX)
-        aws_lambda_invocation_event_counter.inc()
         # Register duration gauge.
         aws_lambda_duration_gauge = reg.gauge(METRIC_PREFIX + "duration")
         # Register error counter.
         aws_lambda_errors_counter = delta.delta_counter(reg, METRIC_PREFIX + "errors")
-        aws_lambda_error_event_counter = reg.counter(METRIC_PREFIX + "error" + METRIC_EVENT_SUFFIX)
         time_start = datetime.now()
         try:
             result = func(*args, **kwargs)
@@ -48,7 +42,6 @@ def wrapper(func):
         except:
             # Set error counter
             aws_lambda_errors_counter.inc()
-            aws_lambda_error_event_counter.inc()
             raise
         finally:
             time_taken = datetime.now() - time_start


### PR DESCRIPTION
Removing event counters from lambda wrappers as they are redundant , given the existence of delta counter metrics.

Thank you,
Anil


